### PR TITLE
Fix imports of @bokeh/bokehjs

### DIFF
--- a/typescript/vanilla_webpack/README.md
+++ b/typescript/vanilla_webpack/README.md
@@ -103,48 +103,24 @@
     npm install ../../../../bokeh-bokehjs-3.7.0-dev.5.tgz
     ```
 
-10. `tsconfig.json` needs workaround for `@bokehjs` paths, added to the `compilerOptions` section:
-
-    ```json
-    "compilerOptions": {
-      "paths": {
-        "@bokehjs/*": ["./node_modules/@bokeh/bokehjs/build/js/lib/*"]
-      }
-    }
-    ```
-
-11. `webpack.config.ts` needs workaround to resolve `@bokehjs` alias also, added to the top-level of the `config`:
+10. Remove contents of `src/index.ts` and replace with code to create BokehJS plot:
 
     ```typescript
-    const config: webpack.Configuration = {
-      resolve: {
-        alias: {
-          "@bokehjs": path.resolve(__dirname, "node_modules/@bokeh/bokehjs/build/js/lib/")
-        }
-      },
-    }
-    ````
+    import * as Bokeh from "@bokeh/bokehjs";
 
-12. Remove contents of `src/index.ts` and replace with code to create BokehJS plot:
-
-    ```typescript
-    import { Column, ColumnDataSource, version } from "@bokehjs/bokeh";
-    import { figure, show } from "@bokehjs/api/plotting";
-    import { Button } from "@bokehjs/models/widgets";
-
-    console.info("BokehJS version:", version);
+    console.info("BokehJS version:", Bokeh.version);
 
     function create_bokehjs_plot(target_id: string) {
-      const source = new ColumnDataSource({data: { x: [0.1, 0.9], y: [0.1, 0.9], size: [40, 10] }});
+      const source = new Bokeh.ColumnDataSource({data: { x: [0.1, 0.9], y: [0.1, 0.9], size: [40, 10] }});
 
-      const plot = figure({
+      const plot = Bokeh.Plotting.figure({
         title: "Example BokehJS plot", height: 500, width: 500,
         x_range: [0, 1], y_range: [0, 1], sizing_mode: "stretch_width",
       });
 
       plot.scatter({ field: "x" }, { field: "y" }, {source, size: { field: "size" }});
 
-      const button = new Button({label: "Click me to add a point", button_type: "primary"});
+      const button = new Bokeh.Widgets.Button({label: "Click me to add a point", button_type: "primary"});
       function button_callback() {
         const data = source.data as any;
         data.x.push(Math.random());
@@ -154,14 +130,14 @@
       }
       button.on_click(button_callback);
 
-      const column = new Column({children: [plot, button], sizing_mode: "stretch_width"});
-      show(column, target_id);
+      const column = new Bokeh.Column({children: [plot, button], sizing_mode: "stretch_width"});
+      Bokeh.Plotting.show(column, target_id);
     }
 
     create_bokehjs_plot("#target");
     ```
 
-13. Rebuild and serve
+11. Rebuild and serve
 
     ```bash
     npm install


### PR DESCRIPTION
Fix the imports of `@bokeh/bokehjs` so we don't need any path workarounds in `tsconfig.json` or `webpack.config.ts`. The form used here is:

```typescript
import * as Bokeh from "@bokeh/bokehjs";

const source = new Bokeh.ColumnDataSource(...);
const plot = Bokeh.Plotting.figure(...);
const button = new Bokeh.Widgets.Button(...);
Bokeh.Plotting.show(...);
```

An alternative more explicit approach is:

```typescript
import { ColumnDataSource, Plotting, Widgets } from "@bokeh/bokehjs";`

const source = newColumnDataSource(...);
const plot = Plotting.figure(...);
const button = new Widgets.Button(...);
Plotting.show(...);
```

I prefer the latter but the former is consistent with the approach used in the existing Bokeh docs at https://docs.bokeh.org/en/latest/docs/user_guide/advanced/bokehjs.html, so we will use that.