### PR TITLE
Support creation of 1+ named recipes rather than all of them

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -10,3 +10,8 @@ npm run create
 ```
 
 This will overwrite all existing recipes. If you are happy with the changes, `git commit` them.
+
+To recreate one or more named recipes rather than all of them use:
+```bash
+npm run create -- VanillaWebpack VanillaRspack
+```

--- a/recipes/src/runner.ts
+++ b/recipes/src/runner.ts
@@ -3,7 +3,21 @@ import * as allRecipes from './recipes/typescript';
 
 const writers: Writer[] = [new BashWriter(), new ReadmeWriter()];
 
-for (const cls of Object.values(allRecipes)) {
+let recipeNames = Object.keys(allRecipes);
+if (process.argv.length > 2) {
+  recipeNames = process.argv.slice(2).map((arg) => arg + 'Recipe');
+
+  const unknownNames = recipeNames.filter(name => !(name in allRecipes));
+  if (unknownNames.length > 0) {
+    console.error("Unknown recipe name(s):", unknownNames.join(', '));
+    process.exit(1)
+  }
+}
+
+console.log("Creating recipes for", recipeNames);
+
+for (const recipeName of recipeNames) {
+  const cls = allRecipes[recipeName];
   const recipe: Recipe = new (cls as any)();
   console.log(`Recipe ${recipe.type} ${recipe.framework} ${recipe.bundler}`);
 


### PR DESCRIPTION
Support creation of 1+ named recipes rather than all of them. For example in `recipes` directory use
```bash
npm run create -- VanillaWebpack
```
to create just the `VanillaWebpackRecipe`.